### PR TITLE
fix: add missing 'items' to calculate_statistics array schema

### DIFF
--- a/src/mcp_dblp/server.py
+++ b/src/mcp_dblp/server.py
@@ -206,7 +206,7 @@ async def serve() -> None:
                 ),
                 inputSchema={
                     "type": "object",
-                    "properties": {"results": {"type": "array"}},
+                    "properties": {"results": {"type": "array", "items": {"type": "object"}}},
                     "required": ["results"],
                 },
             ),


### PR DESCRIPTION
## Summary

- Add `"items": {"type": "object"}` to the `results` parameter schema in `calculate_statistics`
- Fixes JSON Schema validation error on LLM providers that enforce strict schema compliance (e.g., Anthropic)

Closes #3